### PR TITLE
Add Tennis group to fallbackSports

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -45,6 +45,8 @@ const fallbackSports: Sport[] = [
   { key: "basketball_nba", group: "Basketball", title: "NBA", description: "NBA", active: true, has_outrights: false },
   { key: "baseball_mlb", group: "Baseball", title: "MLB", description: "MLB", active: true, has_outrights: false },
   { key: "icehockey_nhl", group: "Hockey", title: "NHL", description: "NHL", active: true, has_outrights: false },
+  { key: "tennis_atp", group: "Tennis", title: "ATP", description: "ATP", active: true, has_outrights: false },
+  { key: "tennis_wta", group: "Tennis", title: "WTA", description: "WTA", active: true, has_outrights: false },
 ];
 
 function isCiEnv() {


### PR DESCRIPTION
fallbackSports in lib/api.ts covers Fighting/Basketball/Baseball/Hockey but has no Tennis group, so tennis disappears from the nav whenever the API key is absent (CI, local dev without a key, or an upstream failure). This adds ATP/WTA entries in the Tennis group mirroring the existing object shape; tsc and next build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)